### PR TITLE
Fix incorrect Binary Operation Code Generation

### DIFF
--- a/codegen.py
+++ b/codegen.py
@@ -439,9 +439,11 @@ class SourceGenerator(NodeVisitor):
         self.write('}')
 
     def visit_BinOp(self, node):
+        self.write('(')
         self.visit(node.left)
         self.write(' %s ' % BINOP_SYMBOLS[type(node.op)])
         self.visit(node.right)
+        self.write(')')
 
     def visit_BoolOp(self, node):
         self.write('(')


### PR DESCRIPTION
Fixes the following sample code.

``` python
import ast
import codegen
import sys

eval(codegen.to_source(ast.parse('sys.stdout.write(("a" + "b")[:1])')))
```

As this currently _eval()_'s the following code.

``` python
sys.stdout.write('a' + 'b'[:1])
```

Cheers,
Jurriaan
